### PR TITLE
Add automatic database detection and binary control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Encore IntelliJ Plugin Changelog
 
 ## [Unreleased]
+### Added
+- From Encore v1.9.3 services databases can be automatically detected and configured within the IDE.
+  This will add both the local database used by `encore run` and the test database used by `encore test`
 
 ## [0.0.3]
 ### Bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - From Encore v1.9.3 services databases can be automatically detected and configured within the IDE.
   This will add both the local database used by `encore run` and the test database used by `encore test`
+- New settings panel which allows the plugin to be configured to use a different encore binary (useful when testing features) 
 
 ## [0.0.3]
 ### Bugs

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = dev.encore.intellij
 pluginName = Encore
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.3
+pluginVersion = 0.1.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
@@ -18,7 +18,7 @@ platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = org.jetbrains.plugins.go
+platformPlugins = org.jetbrains.plugins.go, com.intellij.database
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 7.5.1

--- a/src/main/kotlin/dev/encore/intellij/Encore.kt
+++ b/src/main/kotlin/dev/encore/intellij/Encore.kt
@@ -1,0 +1,25 @@
+package dev.encore.intellij
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.util.text.SemVer
+
+object Encore {
+    val LOG: Logger = Logger.getInstance(Encore.javaClass)
+
+    /* Is encore installed? */
+    @Volatile
+    var encoreInstalled = false
+
+    /* What version is Encore? */
+    @Volatile
+    var encoreVersion: SemVer? = null
+
+    /*
+    Returns true if Encore is at least at the given release
+     */
+    fun isAtLeast(major: Int, minor: Int, patch: Int): Boolean {
+        val version = encoreVersion ?: return false
+
+        return version.isGreaterOrEqualThan(major, minor, patch)
+    }
+}

--- a/src/main/kotlin/dev/encore/intellij/StartupActivity.kt
+++ b/src/main/kotlin/dev/encore/intellij/StartupActivity.kt
@@ -28,7 +28,7 @@ class StartupActivity : StartupActivity.Background, StartupActivity.RequiredForS
         Encore.encoreInstalled = true
 
         // Get the version
-        val versionString = versionOutput.trim().removePrefix("encore version ")
+        val versionString = versionOutput.trim().lines()[0].removePrefix("encore version ")
         if (versionString.startsWith("v")) {
             Encore.encoreVersion = SemVer.parseFromText(versionString.removePrefix("v"))
         } else {

--- a/src/main/kotlin/dev/encore/intellij/StartupActivity.kt
+++ b/src/main/kotlin/dev/encore/intellij/StartupActivity.kt
@@ -1,0 +1,46 @@
+package dev.encore.intellij
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import com.intellij.util.text.SemVer
+import dev.encore.intellij.sqldb.Detector
+import dev.encore.intellij.utils.isInEncoreApp
+import dev.encore.intellij.utils.runEncoreCommand
+
+/*
+ * Startup Activity allows us to run blocking external calls to the encore daemon to extract information
+ * about the project, which we can then store and reference at runtime
+ */
+class StartupActivity : StartupActivity.Background, StartupActivity.RequiredForSmartMode {
+    override fun runActivity(project: Project) {
+        // Skip our startup if it's not an Encore app
+        if (!isInEncoreApp(project)) {
+            return
+        }
+
+        Encore.LOG.info("Performing startup activity for Encore...")
+
+        // Verify Encore is installed
+        val versionOutput = runEncoreCommand(project, "version") ?: return
+        if (!versionOutput.startsWith("encore version ")) {
+            return
+        }
+        Encore.encoreInstalled = true
+
+        // Get the version
+        val versionString = versionOutput.trim().removePrefix("encore version ")
+        if (versionString.startsWith("v")) {
+            Encore.encoreVersion = SemVer.parseFromText(versionString.removePrefix("v"))
+        } else {
+            // If the version string doesn't start with v then it's a dev build, so default to 999.999.999
+            Encore.encoreVersion = SemVer(versionString, 999, 999, 999)
+        }
+        Encore.LOG.info("Verified that Encore is installed and running version ${Encore.encoreVersion}")
+
+        // Ask encore for the database connection info
+        if (Encore.isAtLeast(1, 9, 2)) {
+            Encore.LOG.info("Getting database connection information from Encore...")
+            Detector.loadDatabaseConnection(project)
+        }
+    }
+}

--- a/src/main/kotlin/dev/encore/intellij/liveTemplates/EncoreContext.kt
+++ b/src/main/kotlin/dev/encore/intellij/liveTemplates/EncoreContext.kt
@@ -2,23 +2,10 @@ package dev.encore.intellij.liveTemplates
 
 import com.intellij.codeInsight.template.TemplateActionContext
 import com.intellij.codeInsight.template.TemplateContextType
-import com.intellij.psi.PsiDirectory
+import dev.encore.intellij.utils.isInEncoreApp
 
 class EncoreContext : TemplateContextType("ENCORE_GO_FILE", "Encore Go File") {
     override fun isInContext(templateActionContext: TemplateActionContext): Boolean {
-        return isEncoreApp(templateActionContext.file.originalFile.containingDirectory) && templateActionContext.file.name.endsWith(".go")
-    }
-
-    private fun isEncoreApp(dir: PsiDirectory?): Boolean {
-        if (dir == null) {
-            return false
-        }
-
-        val appFile = dir.findFile("encore.app")
-        if (appFile != null && appFile.isValid) {
-            return true
-        }
-
-        return isEncoreApp(dir.parentDirectory)
+        return isInEncoreApp(templateActionContext.file.originalFile.containingDirectory) && templateActionContext.file.name.endsWith(".go")
     }
 }

--- a/src/main/kotlin/dev/encore/intellij/runconfig/EncoreRunConfig.kt
+++ b/src/main/kotlin/dev/encore/intellij/runconfig/EncoreRunConfig.kt
@@ -8,12 +8,12 @@ import com.goide.execution.testing.GoTestRunConfiguration
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.target.TargetedCommandLineBuilder
 import com.intellij.execution.target.value.TargetValue
-import com.intellij.openapi.project.rootManager
+import dev.encore.intellij.utils.isInEncoreApp
 
 class EncoreRunConfig : GoRunConfigurationExtension() {
     override fun isApplicableFor(configuration: GoRunConfigurationBase<*>): Boolean {
         if (configuration is GoTestRunConfiguration) {
-            return isEncoreApp(configuration)
+            return isInEncoreApp(configuration.defaultModule)
         }
         return false
     }
@@ -23,7 +23,7 @@ class EncoreRunConfig : GoRunConfigurationExtension() {
         runnerSettings: RunnerSettings?
     ): Boolean {
         if (applicableConfiguration is GoTestRunConfiguration) {
-            return isEncoreApp(applicableConfiguration)
+            return isInEncoreApp(applicableConfiguration.defaultModule)
         }
         return false
     }
@@ -50,18 +50,8 @@ class EncoreRunConfig : GoRunConfigurationExtension() {
             }
         }
         if (useEncoreBinary) {
-            cmdLine.exePath = TargetValue.fixed("encore")
+            cmdLine.exePath = TargetValue.fixed("/Users/dom/bin/encoretmp/build_encoretmp")
         }
         super.patchCommandLine(configuration, runnerSettings, cmdLine, runnerId, state, commandLineType)
-    }
-
-    private fun isEncoreApp(configuration: GoRunConfigurationBase<*>): Boolean {
-        for (folder in configuration.getDefaultModule().rootManager.contentRoots) {
-            val appFile = folder.findChild("encore.app")
-            if (appFile != null && appFile.exists()) {
-                return true
-            }
-        }
-        return false
     }
 }

--- a/src/main/kotlin/dev/encore/intellij/runconfig/EncoreRunConfig.kt
+++ b/src/main/kotlin/dev/encore/intellij/runconfig/EncoreRunConfig.kt
@@ -8,6 +8,7 @@ import com.goide.execution.testing.GoTestRunConfiguration
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.target.TargetedCommandLineBuilder
 import com.intellij.execution.target.value.TargetValue
+import dev.encore.intellij.settings.settingsState
 import dev.encore.intellij.utils.isInEncoreApp
 
 class EncoreRunConfig : GoRunConfigurationExtension() {
@@ -50,7 +51,7 @@ class EncoreRunConfig : GoRunConfigurationExtension() {
             }
         }
         if (useEncoreBinary) {
-            cmdLine.exePath = TargetValue.fixed("/Users/dom/bin/encoretmp/build_encoretmp")
+            cmdLine.exePath = TargetValue.fixed(settingsState().encoreBinary)
         }
         super.patchCommandLine(configuration, runnerSettings, cmdLine, runnerId, state, commandLineType)
     }

--- a/src/main/kotlin/dev/encore/intellij/settings/Settings.kt
+++ b/src/main/kotlin/dev/encore/intellij/settings/Settings.kt
@@ -1,0 +1,42 @@
+package dev.encore.intellij.settings
+
+import com.intellij.openapi.options.Configurable
+import javax.swing.JComponent
+
+class Settings : Configurable {
+    private var mySettingsComponent: SettingsPanel? = null
+
+    override fun createComponent(): JComponent {
+        mySettingsComponent = SettingsPanel()
+        return mySettingsComponent!!.getPanel()
+    }
+
+    override fun isModified(): Boolean {
+        val settings = settingsState()
+        var modified = false
+        modified = modified || mySettingsComponent!!.getEnable() != settings.enabled
+        modified = modified || mySettingsComponent!!.getFile() != settings.encoreBinary
+
+        return modified
+    }
+
+    override fun apply() {
+        val settings = settingsState()
+        settings.enabled = mySettingsComponent!!.getEnable()
+        settings.encoreBinary = mySettingsComponent!!.getFile()
+    }
+
+    override fun reset() {
+        val settings = settingsState()
+        mySettingsComponent!!.setEnable(settings.enabled)
+        mySettingsComponent!!.setFile(settings.encoreBinary)
+    }
+
+    override fun disposeUIResources() {
+        mySettingsComponent = null
+    }
+
+    override fun getDisplayName(): String {
+        return "Encore"
+    }
+}

--- a/src/main/kotlin/dev/encore/intellij/settings/SettingsPanel.kt
+++ b/src/main/kotlin/dev/encore/intellij/settings/SettingsPanel.kt
@@ -1,0 +1,57 @@
+package dev.encore.intellij.settings
+
+import com.intellij.openapi.ui.TextComponentAccessor
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.FormBuilder
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class SettingsPanel {
+    private val myMainPanel: JPanel
+    private val enableStatus: JBCheckBox = JBCheckBox("Enable Encore plugin", true)
+    private val file = TextFieldWithBrowseButton()
+
+    init {
+        myMainPanel = FormBuilder.createFormBuilder()
+            .addSeparator()
+            .addLabeledComponent("Enable plugin", enableStatus)
+            .addLabeledComponent("Path to Encore binary", file)
+            .addComponent(JBLabel("If changing the Encore binary, you will need to reopen your project to pickup the new version"))
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+    }
+
+    fun getPanel(): JPanel {
+        file.addBrowseFolderListener(
+            "",
+            "Path to encore binary",
+            null,
+            encoreBinaryDescriptor(),
+            TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT,
+        )
+
+        return myMainPanel
+    }
+
+    fun getPreferredFocusedComponent(): JComponent {
+        return enableStatus
+    }
+
+    fun getEnable(): Boolean {
+        return enableStatus.isSelected
+    }
+
+    fun setEnable(newStatus: Boolean) {
+        enableStatus.isSelected = newStatus
+    }
+
+    fun getFile(): String {
+        return file.text
+    }
+
+    fun setFile(newFile: String) {
+        file.text = newFile
+    }
+}

--- a/src/main/kotlin/dev/encore/intellij/settings/SettingsState.kt
+++ b/src/main/kotlin/dev/encore/intellij/settings/SettingsState.kt
@@ -1,0 +1,28 @@
+package dev.encore.intellij.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+@State(
+    name = "SettingsState",
+    storages = [Storage("EncorePlugin.xml")]
+)
+class SettingsState : PersistentStateComponent<SettingsState> {
+    var enabled: Boolean = true
+    var encoreBinary: String = "encore"
+
+    override fun getState(): SettingsState {
+        return this
+    }
+
+    override fun loadState(state: SettingsState) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+}
+
+fun settingsState(): SettingsState {
+    return ApplicationManager.getApplication().getService(SettingsState::class.java)
+}

--- a/src/main/kotlin/dev/encore/intellij/settings/encoreBinaryDescriptor.kt
+++ b/src/main/kotlin/dev/encore/intellij/settings/encoreBinaryDescriptor.kt
@@ -1,0 +1,39 @@
+package dev.encore.intellij.settings
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.vfs.VirtualFile
+import java.util.concurrent.TimeUnit
+
+class encoreBinaryDescriptor: FileChooserDescriptor(true, false, false, false, false, false) {
+    override fun validateSelectedFiles(files: Array<out VirtualFile>) {
+        if (files.isEmpty()) {
+            throw Exception("You must select an path to the encore binary")
+        }
+
+        if (files.size > 1) {
+            throw Exception("You must only pick one binary")
+        }
+
+        if (files[0].isDirectory) {
+            throw Exception("Cannot be passed a directory")
+        }
+
+        val command = "${files[0].path} version"
+        val parts = command.split("\\s".toRegex())
+        val proc = ProcessBuilder(*parts.toTypedArray())
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+
+        proc.waitFor(5, TimeUnit.SECONDS)
+        if (proc.exitValue() != 0) {
+            val error = proc.errorStream.bufferedReader().readText()
+            throw Exception("When querying for the Encore version, got an error:\n\n${error}")
+        }
+        proc.destroy()
+        val versionString = proc.inputStream.bufferedReader().readText()
+        if (!versionString.trim().startsWith("encore version ")) {
+            throw Exception("Binary did not report `encore version ` as a response to a request for version parameters")
+        }
+    }
+}

--- a/src/main/kotlin/dev/encore/intellij/sqldb/Detector.kt
+++ b/src/main/kotlin/dev/encore/intellij/sqldb/Detector.kt
@@ -1,0 +1,127 @@
+package dev.encore.intellij.sqldb
+
+import com.intellij.database.Dbms
+import com.intellij.database.autoconfig.DataSourceDetector
+import com.intellij.database.dataSource.*
+import com.intellij.database.model.DasDataSource
+import com.intellij.database.model.ObjectKind
+import com.intellij.database.model.ObjectName
+import com.intellij.database.util.TreePattern
+import com.intellij.database.util.TreePatternNode
+import com.intellij.database.util.TreePatternNode.NegativeNaming
+import com.intellij.database.util.TreePatternNode.PositiveNaming
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiFile
+import com.intellij.util.queryParameters
+import dev.encore.intellij.Encore
+import dev.encore.intellij.utils.isInEncoreApp
+import dev.encore.intellij.utils.runEncoreCommand
+import java.net.URI
+
+class Detector : DataSourceDetector() {
+    override fun collectDataSources(module: Module, builder: Builder, onTheFly: Boolean) {
+        if (Encore.encoreInstalled && !isInEncoreApp(module)) {
+            return
+        }
+
+        // Get connection URI from encore and extract the app name
+        val uri = module.project.getUserData(DatabaseConnection) ?: return
+        val loginParts = uri.userInfo.split(":")
+        val appName = loginParts[0]
+
+        // IntelliJ's database can parse URLs in the following format
+        // We use the username / password in the query string here as work around
+        // as using the `withUser` / `withPassword` doesn't perminately store the password
+        // jdbc:postgresql://[{host::localhost}[:{port::5432}]][/{database:database/[^?]+:postgres}?][\?<&,user={user:param},password={password:param},{:identifier}={:param}>]
+        val query = uri.queryParameters.toMutableMap()
+        query["user"] = appName
+
+        // Propose the local environment
+        query["password"] = "local"
+        val localQueryString = query.toList().joinToString(separator = "&") { "${it.first}=${it.second}" }
+        builder.reset().withDbms(Dbms.POSTGRES)
+            .withGroupName(loginParts[0])
+            .withName("Local Environment")
+            .withComment("Used by `encore run`")
+            .withUrl("jdbc:postgresql://${uri.host}:${uri.port}/postgres?${localQueryString}")
+            .withJdbcAdditionalProperty("domain-auth", "user-pass") // This forces persistent storage of the password
+            .withCallback(ApplyAdditionalConnectionSettings())
+            .commit()
+
+        // Propose the test environment
+        query["password"] = "test"
+        val testQueryString = query.toList().joinToString(separator = "&") { "${it.first}=${it.second}" }
+        builder.reset().withDbms(Dbms.POSTGRES)
+            .withGroupName(loginParts[0])
+            .withName("Local Test Environment")
+            .withComment("Used by `encore test`")
+            .withUrl("jdbc:postgresql://${uri.host}:${uri.port}/postgres?${testQueryString}")
+            .withJdbcAdditionalProperty("domain-auth", "user-pass") // This forces persistent storage of the password
+            .withCallback(ApplyAdditionalConnectionSettings())
+            .commit()
+    }
+
+    override fun isRelevantFile(file: PsiFile): Boolean {
+        return isInEncoreApp(file.containingDirectory)
+    }
+
+    companion object {
+        val DatabaseConnection = Key<URI?>("encore-db-uri")
+
+        /** Stores this in the use data, to be read by the discovery read only thread later */
+        fun loadDatabaseConnection(project: Project): URI? {
+            try {
+                var connectionURL = runEncoreCommand(project, "db", "conn-uri", "-e", "local", "_any_") ?: return null
+                connectionURL = connectionURL.trim()
+
+                project.putUserData(DatabaseConnection, URI(connectionURL))
+            } catch (e: Exception) {
+                Encore.LOG.error("unable to get connection URI from encore daemon", e)
+                project.putUserData(DatabaseConnection, null)
+            }
+
+            return null
+        }
+    }
+
+    private class ApplyAdditionalConnectionSettings : Callback() {
+        override fun onCreated(dataSource: DasDataSource) {
+            val source = dataSource.localDataSource ?: return
+
+            // Create the default pattern of what databases and schemas
+            // we want IntelliJ to index
+            val treePattern = TreePattern(
+                TreePatternNode.Group(
+                    ObjectKind.DATABASE,
+                    null, // All positive names allowed
+                    TreePatternNode(
+                        NegativeNaming(
+                            ObjectName("postgres", false), // Don't show the default postgres database
+
+                            // IntelliJ bug where on first load it shows these two and then complains  that they
+                            // don't exist
+                            ObjectName("template0", false),
+                            ObjectName("template1", false),
+                        ),
+                        arrayOf(
+                            TreePatternNode.Group(
+                                ObjectKind.SCHEMA,
+                                arrayOf(
+                                    // We only want to pickup public schema's
+                                    TreePatternNode(
+                                        PositiveNaming(ObjectName("public", false)),
+                                        arrayOf(),
+                                    )
+                                ),
+                                null
+                            )
+                        ),
+                    ),
+                )
+            )
+            source.schemaMapping.introspectionScope = treePattern
+        }
+    }
+}

--- a/src/main/kotlin/dev/encore/intellij/utils/appdetector.kt
+++ b/src/main/kotlin/dev/encore/intellij/utils/appdetector.kt
@@ -2,6 +2,7 @@ package dev.encore.intellij.utils
 
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.project.modules
 import com.intellij.openapi.project.rootManager
 import com.intellij.psi.PsiDirectory
@@ -45,10 +46,10 @@ fun isInEncoreApp(project: Project): Boolean {
         return false
     }
 
-    for (module in project.modules) {
-        if (isInEncoreApp(module)) {
-            return true
-        }
+    val projectDir = project.guessProjectDir() ?: return false
+    val appFile = projectDir.findChild(EncoreAppFile)
+    if (appFile != null && appFile.exists()) {
+        return true
     }
     return false
 }

--- a/src/main/kotlin/dev/encore/intellij/utils/appdetector.kt
+++ b/src/main/kotlin/dev/encore/intellij/utils/appdetector.kt
@@ -1,0 +1,41 @@
+package dev.encore.intellij.utils
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.modules
+import com.intellij.openapi.project.rootManager
+import com.intellij.psi.PsiDirectory
+
+const val EncoreAppFile = "encore.app"
+
+fun isInEncoreApp(dir: PsiDirectory?): Boolean {
+    if (dir == null) {
+        return false
+    }
+
+    val appFile = dir.findFile(EncoreAppFile)
+    if (appFile != null && appFile.isValid) {
+        return true
+    }
+
+    return isInEncoreApp(dir.parentDirectory)
+}
+
+fun isInEncoreApp(module: Module): Boolean {
+    for (folder in module.rootManager.contentRoots) {
+        val appFile = folder.findChild(EncoreAppFile)
+        if (appFile != null && appFile.exists()) {
+            return true
+        }
+    }
+    return false
+}
+
+fun isInEncoreApp(project: Project): Boolean {
+    for (module in project.modules) {
+        if (isInEncoreApp(module)) {
+            return true
+        }
+    }
+    return false
+}

--- a/src/main/kotlin/dev/encore/intellij/utils/appdetector.kt
+++ b/src/main/kotlin/dev/encore/intellij/utils/appdetector.kt
@@ -5,10 +5,15 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.modules
 import com.intellij.openapi.project.rootManager
 import com.intellij.psi.PsiDirectory
+import dev.encore.intellij.settings.settingsState
 
 const val EncoreAppFile = "encore.app"
 
 fun isInEncoreApp(dir: PsiDirectory?): Boolean {
+    if (!settingsState().enabled) {
+        return false
+    }
+
     if (dir == null) {
         return false
     }
@@ -22,6 +27,10 @@ fun isInEncoreApp(dir: PsiDirectory?): Boolean {
 }
 
 fun isInEncoreApp(module: Module): Boolean {
+    if (!settingsState().enabled) {
+        return false
+    }
+
     for (folder in module.rootManager.contentRoots) {
         val appFile = folder.findChild(EncoreAppFile)
         if (appFile != null && appFile.exists()) {
@@ -32,6 +41,10 @@ fun isInEncoreApp(module: Module): Boolean {
 }
 
 fun isInEncoreApp(project: Project): Boolean {
+    if (!settingsState().enabled) {
+        return false
+    }
+
     for (module in project.modules) {
         if (isInEncoreApp(module)) {
             return true

--- a/src/main/kotlin/dev/encore/intellij/utils/encore.kt
+++ b/src/main/kotlin/dev/encore/intellij/utils/encore.kt
@@ -1,0 +1,30 @@
+package dev.encore.intellij.utils
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ScriptRunnerUtil
+import com.intellij.openapi.project.Project
+import dev.encore.intellij.Encore
+
+
+/**
+ * This command runs the given command against Encore within the projects base path
+ *
+ * If the command takes more than 30 seconds to complete or reports an error, null is returned
+ *
+ * This must be called from background threads, and cannot be called from Read threads - otherwise
+ * IntelliJ will throw an exception
+ */
+fun runEncoreCommand(project: Project, vararg argsToEncore: String): String? {
+    val cmdLine = GeneralCommandLine()
+    cmdLine.setWorkDirectory(project.basePath)
+    cmdLine.exePath = "encore"
+    cmdLine.addParameters(argsToEncore.toMutableList())
+
+    return try {
+        ScriptRunnerUtil.getProcessOutput(cmdLine, ScriptRunnerUtil.STDOUT_OUTPUT_KEY_FILTER, 30000)
+    } catch (e: ExecutionException) {
+        Encore.LOG.error("Unable to execute command: ${argsToEncore.joinToString(" ")}", e)
+        null
+    }
+}

--- a/src/main/kotlin/dev/encore/intellij/utils/encore.kt
+++ b/src/main/kotlin/dev/encore/intellij/utils/encore.kt
@@ -5,6 +5,7 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ScriptRunnerUtil
 import com.intellij.openapi.project.Project
 import dev.encore.intellij.Encore
+import dev.encore.intellij.settings.settingsState
 
 
 /**
@@ -18,7 +19,7 @@ import dev.encore.intellij.Encore
 fun runEncoreCommand(project: Project, vararg argsToEncore: String): String? {
     val cmdLine = GeneralCommandLine()
     cmdLine.setWorkDirectory(project.basePath)
-    cmdLine.exePath = "encore"
+    cmdLine.exePath = settingsState().encoreBinary
     cmdLine.addParameters(argsToEncore.toMutableList())
 
     return try {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,11 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>org.jetbrains.plugins.go</depends>
+    <depends>com.intellij.database</depends>
+
+    <extensions defaultExtensionNs="com.intellij.database">
+        <dataSourceDetector implementation="dev.encore.intellij.sqldb.Detector" />
+    </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
         <defaultLiveTemplates file="/liveTemplates/Encore.xml"/>
@@ -30,6 +35,8 @@
                 language="JSON5"
                 fileNamesCaseInsensitive="encore.app"
             />
+
+        <requiredForSmartModeStartupActivity implementation="dev.encore.intellij.StartupActivity" />
     </extensions>
 
     <extensions defaultExtensionNs="com.goide">

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,6 +37,15 @@
             />
 
         <requiredForSmartModeStartupActivity implementation="dev.encore.intellij.StartupActivity" />
+
+        <applicationService serviceImplementation="dev.encore.intellij.settings.SettingsState" />
+
+        <applicationConfigurable
+                parentId="tools"
+                instance="dev.encore.intellij.settings.Settings"
+                id="dev.encore.intellij.settings.Settings"
+                displayName="Encore"/>
+        />
     </extensions>
 
     <extensions defaultExtensionNs="com.goide">


### PR DESCRIPTION
## Automatic Database Detection

This set of commits adds the ability for the plugin to detect the Encore database and give the user the ability to automatically add it into their IDE.

<img width="411" alt="image" src="https://user-images.githubusercontent.com/236641/198674824-5562c52b-46b5-49db-b9d2-bedbe6cc11f7.png">
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/236641/198674865-71ffacbd-9aee-487c-a281-3902587e40e1.png">
<img width="482" alt="image" src="https://user-images.githubusercontent.com/236641/198674977-7e72140d-3f34-45d1-bc1e-084b26493b8c.png">

## Settings Panel

It also adds a new settings panel, which allows the user to disable the plugin, and change which encore binary is being used by the plugin. (This is useful when developing new features)

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/236641/198675166-42287d0a-381e-4dc3-be10-22d129f0d254.png">

The plugin verifies the binary correctl responds to a call to `encore version` and prevents an invalid binary from being selected:

<img width="398" alt="image" src="https://user-images.githubusercontent.com/236641/198675335-226baeab-591a-40c6-9c12-e5ac87ff41da.png">

