### PR TITLE
Support GoLand 2023.1 & add Directive Annotators

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# GitHub Actions Workflow created for testing and preparing the plugin release in following steps:
+# GitHub Actions Workflow is created for testing and preparing the plugin release in the following steps:
 # - validate Gradle Wrapper,
 # - run 'test' and 'verifyPlugin' tasks,
 # - run Qodana inspections,
@@ -46,7 +46,7 @@ jobs:
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1.0.5
+        uses: gradle/wrapper-validation-action@v1.0.6
 
       # Setup Java 11 environment for the next steps
       - name: Setup Java
@@ -64,14 +64,14 @@ jobs:
           VERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"
           NAME="$(echo "$PROPERTIES" | grep "^pluginName:" | cut -f2- -d ' ')"
           CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
 
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=name::$NAME"
-          echo "::set-output name=changelog::$CHANGELOG"
-          echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
+          
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
           ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
 
@@ -102,7 +102,7 @@ jobs:
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
-        run: ./gradlew runPluginVerifier -Pplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew runPluginVerifier -Dplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result
@@ -114,7 +114,7 @@ jobs:
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v2022.2.3
+        uses: JetBrains/qodana-action@v2022.3.4
 
       # Prepare plugin archive content for creating artifact
       - name: Prepare Plugin Artifact
@@ -125,7 +125,7 @@ jobs:
           FILENAME=`ls *.zip`
           unzip "$FILENAME" -d content
 
-          echo "::set-output name=filename::${FILENAME:0:-4}"
+          echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
 
       # Store already-built plugin as an artifact for downloading
       - name: Upload artifact
@@ -149,7 +149,7 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v3
 
-      # Remove old release drafts by using the curl request for the available releases with draft flag
+      # Remove old release drafts by using the curl request for the available releases with a draft flag
       - name: Remove Old Release Drafts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
             --jq '.[] | select(.draft == true) | .id' \
             | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
 
-      # Create new release draft - which is not publicly visible and requires manual acceptance
+      # Create a new release draft which is not publicly visible and requires manual acceptance
       - name: Create Release Draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
-# GitHub Actions Workflow created for handling the release process based on the draft release prepared
-# with the Build workflow. Running the publishPlugin task requires the PUBLISH_TOKEN secret provided.
+# GitHub Actions Workflow created for handling the release process based on the draft release prepared with the Build workflow.
+# Running the publishPlugin task requires all following secrets to be provided: PUBLISH_TOKEN, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, CERTIFICATE_CHAIN.
+# See https://plugins.jetbrains.com/docs/intellij/plugin-signing.html for more information.
 
 name: Release
 on:
@@ -40,11 +41,9 @@ jobs:
           EOM
           )"
           
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
-
-          echo "::set-output name=changelog::$CHANGELOG"
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       # Update Unreleased section with the current release note
       - name: Patch Changelog

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,9 +4,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="delegatedBuild" value="true" />
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="11" />
         <option name="modules">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 - Support for GoLand 2023.1
+- Add support for annotating Encore API directives, with some basic validation
 
 ## 0.1.2 - 2022-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Encore IntelliJ Plugin Changelog
 
 ## Unreleased
+- Support for GoLand 2023.1
 
 ## 0.1.2 - 2022-12-09
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,15 +2,16 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-fun properties(key: String) = project.findProperty(key).toString()
+fun properties(key: String) = providers.gradleProperty(key)
+fun environment(key: String) = providers.environmentVariable(key)
 
 plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.7.21"
+    id("org.jetbrains.kotlin.jvm") version "1.8.10"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.10.0"
+    id("org.jetbrains.intellij") version "1.13.2"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "2.0.0"
     // Gradle Qodana Plugin
@@ -19,45 +20,43 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.6.1"
 }
 
-group = properties("pluginGroup")
-version = properties("pluginVersion")
+group = properties("pluginGroup").get()
+version = properties("pluginVersion").get()
 
 // Configure project's dependencies
 repositories {
     mavenCentral()
 }
 
-// Set the JVM language level used to compile sources and generate files - Java 11 is required since 2020.3
+// Set the JVM language level used to build the project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.
 kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
+    jvmToolchain(11)
 }
 
-// Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
+// Configure Gradle IntelliJ Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
     pluginName.set(properties("pluginName"))
     version.set(properties("platformVersion"))
     type.set(properties("platformType"))
-    downloadSources.set(properties("platformDownloadSources").toBoolean())
+    downloadSources.set(properties("platformDownloadSources").get().toBoolean())
     updateSinceUntilBuild.set(true)
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+    plugins.set(properties("platformPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
 }
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
 changelog {
-    version.set(properties("pluginVersion"))
-    groups.set(emptyList())
+    groups.empty()
+    repositoryUrl.set(properties("pluginRepositoryUrl"))
 }
 
 // Configure Gradle Qodana Plugin - read more: https://github.com/JetBrains/gradle-qodana-plugin
 qodana {
-    cachePath.set(projectDir.resolve(".qodana").canonicalPath)
-    reportPath.set(projectDir.resolve("build/reports/inspections").canonicalPath)
+    cachePath.set(provider { file(".qodana").canonicalPath })
+    reportPath.set(provider { file("build/reports/inspections").canonicalPath })
     saveReport.set(true)
-    showReport.set(System.getenv("QODANA_SHOW_REPORT")?.toBoolean() ?: false)
+    showReport.set(environment("QODANA_SHOW_REPORT").map { it.toBoolean() }.getOrElse(false))
 }
 
 // Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
@@ -67,7 +66,7 @@ kover.xmlReport {
 
 tasks {
     wrapper {
-        gradleVersion = properties("gradleVersion")
+        gradleVersion = properties("gradleVersion").get()
     }
 
     patchPluginXml {
@@ -76,23 +75,26 @@ tasks {
         untilBuild.set(properties("pluginUntilBuild"))
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription.set(
-            projectDir.resolve("README.md").readText().lines().run {
-                val start = "<!-- Plugin description -->"
-                val end = "<!-- Plugin description end -->"
+        pluginDescription.set(providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
+            val start = "<!-- Plugin description -->"
+            val end = "<!-- Plugin description end -->"
 
+            with (it.lines()) {
                 if (!containsAll(listOf(start, end))) {
                     throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
                 }
-                subList(indexOf(start) + 1, indexOf(end))
-            }.joinToString("\n").run { markdownToHTML(this) }
-        )
+                subList(indexOf(start) + 1, indexOf(end)).joinToString("\n").let(::markdownToHTML)
+            }
+        })
 
+        val changelog = project.changelog // local variable for configuration cache compatibility
         // Get the latest available change notes from the changelog file
-        changeNotes.set(provider {
+        changeNotes.set(properties("pluginVersion").map { pluginVersion ->
             with(changelog) {
                 renderItem(
-                    getOrNull(properties("pluginVersion")) ?: getLatest(),
+                    (getOrNull(pluginVersion) ?: getUnreleased())
+                        .withHeader(false)
+                        .withEmptySections(false),
                     Changelog.OutputType.HTML,
                 )
             }
@@ -109,28 +111,17 @@ tasks {
     }
 
     signPlugin {
-        certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
-        privateKey.set(System.getenv("PRIVATE_KEY"))
-        password.set(System.getenv("PRIVATE_KEY_PASSWORD"))
+        certificateChain.set(environment("CERTIFICATE_CHAIN"))
+        privateKey.set(environment("PRIVATE_KEY"))
+        password.set(environment("PRIVATE_KEY_PASSWORD"))
     }
 
     publishPlugin {
         dependsOn("patchChangelog")
-        token.set(System.getenv("PUBLISH_TOKEN"))
-        // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
+        token.set(environment("PUBLISH_TOKEN"))
+        // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
+        channels.set(properties("pluginVersion").map { listOf(it.split('-').getOrElse(1) { "default" }.split('.').first()) })
     }
-}
-dependencies {
-    implementation(kotlin("stdlib-jdk8"))
-}
-val compileKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions {
-    jvmTarget = "1.8"
-}
-val compileTestKotlin: KotlinCompile by tasks
-compileTestKotlin.kotlinOptions {
-    jvmTarget = "1.8"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@
 pluginGroup = dev.encore.intellij
 pluginName = Encore
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.2
+pluginVersion = 0.1.3
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 223
-pluginUntilBuild = 224.*
+#pluginUntilBuild = 224.* (we can not specify this to allow the plugin to be installed on all future versions
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = GO
-platformVersion = 2022.3
+platformVersion = 2023.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@
 pluginGroup = dev.encore.intellij
 pluginName = Encore
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.3
+pluginVersion = 0.2.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 223
-#pluginUntilBuild = 231.* (we can not specify this to allow the plugin to be installed on all future versions
+#pluginUntilBuild = 231.* # (we can not specify this, otherwise we need to constantly update the plugin to allow the plugin to be installed on all future versions of GoLand)
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = GO

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 0.1.3
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 223
-#pluginUntilBuild = 224.* (we can not specify this to allow the plugin to be installed on all future versions
+#pluginUntilBuild = 231.* (we can not specify this to allow the plugin to be installed on all future versions
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = GO
@@ -21,12 +21,13 @@ platformDownloadSources = true
 platformPlugins = org.jetbrains.plugins.go, com.intellij.database
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 7.5.1
+gradleVersion = 8.0.2
 
 # Opt-out flag for bundling Kotlin standard library.
-# See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
+# See https://jb.gg/intellij-platform-kotlin-stdlib for details.
 # suppress inspection "UnusedProperty"
 kotlin.stdlib.default.dependency = false
 
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html
+# suppress inspection "UnusedProperty"
 org.gradle.unsafe.configuration-cache = true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -80,10 +80,10 @@ do
     esac
 done
 
-APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
-
-APP_NAME="Gradle"
+# This is normally unused
+# shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
+APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
@@ -143,12 +143,16 @@ fi
 if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
+        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
     case $MAX_FD in  #(
       '' | soft) :;; #(
       *)
+        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -26,6 +26,7 @@ if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
 if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 

--- a/src/main/kotlin/dev/encore/intellij/annotators/ApiDecls.kt
+++ b/src/main/kotlin/dev/encore/intellij/annotators/ApiDecls.kt
@@ -1,0 +1,210 @@
+package dev.encore.intellij.annotators
+
+import com.goide.highlighting.GoSyntaxHighlightingColors
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+
+class ApiDecls : Annotator {
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        // If it's not a comment and doesn't start with "//encore:", return
+        // as we're not interested in it
+        if (element !is PsiComment) {
+            return
+        }
+        val comment: PsiComment = element
+        if (!comment.text.startsWith(API_DECL_PREFIX)) {
+            return
+        }
+        val parts = comment.text.removePrefix("//").split(" ")
+        if (parts.isEmpty() || !PREFIXES.containsKey(parts[0]) ) {
+            return
+        }
+
+        val cfg: DeclCfg = PREFIXES[parts[0]]!!
+
+
+        // Highlight the "//encore:" part of the comment as a comment keyword
+        val directiveRange = TextRange.from(comment.textRange.startOffset + 2, parts[0].length)
+        holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+            .range(directiveRange)
+            .textAttributes(GoSyntaxHighlightingColors.COMMENT_KEYWORD)
+            .tooltip(cfg.tooltip)
+            .create()
+
+        // Highlight the rest of the comment
+        var lastIndex = comment.textRange.startOffset + parts[0].length + 3
+        val used = mutableSetOf<String>()
+
+        for (part in parts.drop(1)) {
+            if (part.contains('=')) {
+                // It's a field
+                val splitPoint = part.indexOf('=')
+                val fieldName = part.take(splitPoint)
+                val fieldValue = part.drop(splitPoint + 1)
+                val nameRange = TextRange.from(lastIndex, splitPoint)
+                val valueRange = TextRange.from(lastIndex + splitPoint + 1, fieldValue.length)
+
+
+                // Check it's not already used once
+                if (used.contains(fieldName)) {
+                    holder.newAnnotation(HighlightSeverity.ERROR, "This field cannot be used more than once per directive")
+                        .range(nameRange)
+                        .highlightType(ProblemHighlightType.GENERIC_ERROR)
+                        .create()
+                } else if (!cfg.fieldNames.contains(fieldName)) {
+                    holder.newAnnotation(
+                        HighlightSeverity.ERROR,
+                        "Unknown field name, supported fields are:" + cfg.fieldNames.joinToString(", ")
+                    )
+                        .range(nameRange)
+                        .highlightType(ProblemHighlightType.LIKE_UNKNOWN_SYMBOL)
+                        .create()
+                } else {
+                    // If it's valid then highlight it as so
+                    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                        .range(nameRange)
+                        .textAttributes(GoSyntaxHighlightingColors.GO_BUILD_TAG)
+                        .create()
+                }
+
+                highlightFieldValue(holder, cfg, fieldName, fieldValue, valueRange)
+
+                used.add(fieldName)
+
+            } else {
+                // It's an option
+                val partRange = TextRange.from(lastIndex, part.length)
+
+                // Check it's not already used once
+                if (used.contains(part)) {
+                    // Otherwise, highlight it as an error
+                    holder.newAnnotation(HighlightSeverity.ERROR, "This option cannot be used more than once per directive")
+                        .range(partRange)
+                        .highlightType(ProblemHighlightType.GENERIC_ERROR)
+                        .create()
+                } else if (!cfg.options.contains(part) && !part.startsWith("tag:")) {
+                    // Otherwise, highlight it as an error
+                    holder.newAnnotation(HighlightSeverity.ERROR, "This is not a valid option for this directive, supported options are: " + cfg.options.joinToString(", "))
+                        .range(partRange)
+                        .highlightType(ProblemHighlightType.LIKE_UNKNOWN_SYMBOL)
+                        .create()
+                } else {
+                    // If it's valid then highlight it as so
+                    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                        .range(partRange)
+                        .textAttributes(GoSyntaxHighlightingColors.GO_BUILD_TAG)
+                        .create()
+                }
+
+                used.add(part)
+            }
+
+            lastIndex += part.length + 1
+        }
+    }
+
+    private fun highlightFieldValue(holder: AnnotationHolder, cfg: DeclCfg, fieldName: String, fieldValue: String, range: TextRange) {
+        if (fieldName == "path" && (fieldValue.contains(":") || fieldValue.contains("*"))) {
+            // highlight each segment starting with ":" as a different colour
+            var lastIndex = range.startOffset
+            for (part in fieldValue.split("/")) {
+                // +1 for the slash, but the last one doesn't have one
+                var length = part.length + 1
+                if (lastIndex + length > range.endOffset) {
+                    length = range.endOffset - lastIndex
+                }
+
+                if (part.startsWith(":") || part.startsWith("*")) {
+                    val partRange =  if (length == part.length) {
+                        TextRange.from(lastIndex, length)
+                    } else {
+                        // highlight the following slash as a string
+                        holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                            .range(TextRange.from(lastIndex + length - 1, 1))
+                            .textAttributes(DefaultLanguageHighlighterColors.STRING)
+                            .create()
+
+                        TextRange.from(lastIndex, length - 1)
+                    }
+
+                    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                        .range(partRange)
+                        .textAttributes(GoSyntaxHighlightingColors.LOCAL_VARIABLE)
+                        .create()
+                } else {
+                    val partRange = TextRange.from(lastIndex, length)
+                    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                        .range(partRange)
+                        .textAttributes(DefaultLanguageHighlighterColors.STRING)
+                        .create()
+                }
+                lastIndex += part.length + 1
+            }
+            return
+        } else {
+            // highlight the whole value at once
+            holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                .range(range)
+                .textAttributes(DefaultLanguageHighlighterColors.STRING)
+                .create()
+        }
+    }
+
+    companion object {
+        private const val API_DECL_PREFIX = "//encore:"
+
+        private val PREFIXES = mapOf(
+            "encore:api" to DeclCfg(
+                "This defines an API endpoint",
+                arrayOf("raw", "public", "private", "auth"),
+                arrayOf("path", "method"),
+            ),
+            "encore:service" to DeclCfg(
+                "This defines a service singleton which will be started up along side your service",
+                arrayOf(),
+                arrayOf(),
+            ),
+            "encore:authhandler" to DeclCfg(
+                "This defines an authentication handler which will be used to authenticate requests for your whole application.",
+                arrayOf(),
+                arrayOf(),
+            ),
+            "encore:middleware" to DeclCfg(
+                "This defines a middleware which will be used to process requests",
+                arrayOf("global"),
+                arrayOf("target"),
+            )
+        )
+    }
+}
+
+data class DeclCfg(
+    val tooltip: String,
+    val options: Array<String>,
+    val fieldNames: Array<String>,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DeclCfg
+
+        if (tooltip != other.tooltip) return false
+        if (!options.contentEquals(other.options)) return false
+        return fieldNames.contentEquals(other.fieldNames)
+    }
+
+    override fun hashCode(): Int {
+        var result = tooltip.hashCode()
+        result = 31 * result + options.contentHashCode()
+        result = 31 * result + fieldNames.contentHashCode()
+        return result
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,11 @@
 
         <applicationService serviceImplementation="dev.encore.intellij.settings.SettingsState" />
 
+        <annotator
+            language="go"
+            implementationClass="dev.encore.intellij.annotators.ApiDecls"
+            />
+
         <applicationConfigurable
                 parentId="tools"
                 instance="dev.encore.intellij.settings.Settings"


### PR DESCRIPTION
This PR adds support for GoLand 2023.1 and future releases (by removing the `until` part of the plugin description).

It also adds support for directive annotation within Go code.

<img width="569" alt="image" src="https://user-images.githubusercontent.com/236641/229676463-192039e9-d65f-4bc4-8806-a9be18d9bbd8.png">
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/236641/229676958-a2421aa4-d89a-44b6-892e-dade8c075a1b.png">
